### PR TITLE
Add sensible to_s to make errors readable

### DIFF
--- a/lib/opening_hours_converter/token.rb
+++ b/lib/opening_hours_converter/token.rb
@@ -14,6 +14,10 @@ module OpeningHoursConverter
       @made_from = made_from
     end
 
+    def to_s
+      "Token(value: #{@value}, type: #{@type}, start_index: #{@start_index})"
+    end
+
     def year?
       integer? && @value.length == 4
     end


### PR DESCRIPTION
Lots of parsing errors use "token" but token has no to_s so the errors are often quite useless.

E.g. `can't read current token #<OpeningHoursConverter::Token:0x00007faac847fa48>`.

This fixes that and makes it `can't read current token Token(value: +, type: string, start_index: 17)`

