### PR TITLE
Feature/rspec dep

### DIFF
--- a/lib/opening_hours_converter/token.rb
+++ b/lib/opening_hours_converter/token.rb
@@ -14,6 +14,10 @@ module OpeningHoursConverter
       @made_from = made_from
     end
 
+    def to_s
+      "Token(value: #{@value}, type: #{@type}, start_index: #{@start_index})"
+    end
+
     def year?
       integer? && @value.length == 4
     end

--- a/opening_hours_converter.gemspec
+++ b/opening_hours_converter.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.license = 'AGPL-3.0'
 
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Rspec is used to test the lib, but rspec is not a dependency. 

This breaks bundle and makes it harder for devs to run the tests. Adding it fixes that.