### PR TITLE
Feature/errors

### DIFF
--- a/lib/opening_hours_converter.rb
+++ b/lib/opening_hours_converter.rb
@@ -1,6 +1,7 @@
 module OpeningHoursConverter
   require 'date'
   require_relative './opening_hours_converter/utils'
+  require_relative './opening_hours_converter/errors.rb'
   require_relative './opening_hours_converter/regex_handler'
   require_relative './opening_hours_converter/date_range'
   require_relative './opening_hours_converter/token'

--- a/lib/opening_hours_converter/day.rb
+++ b/lib/opening_hours_converter/day.rb
@@ -17,7 +17,7 @@ module OpeningHoursConverter
 
         off, start_minute, end_minute = handle_interval(interval)
 
-        raise "Invalid interval #{interval.inspect}" if start_minute.nil? && end_minute.nil?
+        raise ParseError, "Invalid interval #{interval.inspect}" if start_minute.nil? && end_minute.nil?
 
         (start_minute..end_minute).step do |minute|
           minute_array[minute] = off ? 'off' : true

--- a/lib/opening_hours_converter/errors.rb
+++ b/lib/opening_hours_converter/errors.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Unable to parse Opening Hours String
+class OpeningHoursConverter::ParseError < StandardError; end

--- a/lib/opening_hours_converter/opening_hours_parser.rb
+++ b/lib/opening_hours_converter/opening_hours_parser.rb
@@ -125,12 +125,12 @@ module OpeningHoursConverter
             elsif !(@regex_handler.week_regex =~ wide_range_selector).nil?
               weeks << get_week(wide_range_selector)
             else
-              raise ArgumentError, "Unsupported selector #{wide_range_selector}"
+              raise ParseError, "Unsupported selector #{wide_range_selector}"
             end
           end
         end
 
-        raise ArgumentError, 'Unreadable string' if @current_token == tokens.length - 1
+        raise ParseError, 'Unreadable string' if @current_token == tokens.length - 1
 
         # puts "weekdays : #{weekdays}"
         # puts "weeks : #{weeks}"

--- a/lib/opening_hours_converter/regex_handler.rb
+++ b/lib/opening_hours_converter/regex_handler.rb
@@ -205,7 +205,7 @@ module OpeningHoursConverter
     end
 
     def int_range(max)
-      raise 'too high' if max > 99
+      raise ArgumentError, 'too high' if max > 99
 
       base = max / 10
 

--- a/lib/opening_hours_converter/token.rb
+++ b/lib/opening_hours_converter/token.rb
@@ -14,6 +14,10 @@ module OpeningHoursConverter
       @made_from = made_from
     end
 
+    def to_s
+      "Token(value: #{@value}, type: #{@type}, start_index: #{@start_index})"
+    end
+
     def year?
       integer? && @value.length == 4
     end

--- a/lib/opening_hours_converter/tokenizer.rb
+++ b/lib/opening_hours_converter/tokenizer.rb
@@ -18,7 +18,7 @@ module OpeningHoursConverter
     def tokenize
       counter = 0
       while @index < @opening_hours_string.length
-        raise 'ups' if counter > 200
+        raise ParseError if counter > 200
         skip_white_spaces
         @tokens << handle_string if string?
 

--- a/lib/opening_hours_converter/tokens_handler.rb
+++ b/lib/opening_hours_converter/tokens_handler.rb
@@ -67,7 +67,7 @@ module OpeningHoursConverter
           next
         end
 
-        raise "can't read current token #{current_token}"
+        raise ParseError, "can't read current token #{current_token}"
       end
     end
 
@@ -105,7 +105,7 @@ module OpeningHoursConverter
             value, made_from, type = add_current_token_to(value, type, made_from)
             next
           end
-          raise "you can\'t have two years with just space between them previous token: #{previous_token}, current token: #{current_token}"
+          raise ParseError, "you can\'t have two years with just space between them previous token: #{previous_token}, current token: #{current_token}"
         end
 
         if current_token.string?
@@ -309,23 +309,23 @@ module OpeningHoursConverter
       made_from = [current_token]
       @index += 1
 
-      raise unless current_token.colon?
+      raise ParseError unless current_token.colon?
       value, made_from, type = add_current_token_to(value, type, made_from)
 
-      raise unless current_token.time?
+      raise ParseError unless current_token.time?
       value, made_from, type = add_current_token_to(value, type, made_from)
 
-      raise unless current_token.hyphen?
+      raise ParseError unless current_token.hyphen?
       value, made_from, type = add_current_token_to(value, type, made_from)
 
       # second part of time range
-      raise unless current_token.time?
+      raise ParseError unless current_token.time?
       value, made_from, type = add_current_token_to(value, type, made_from)
 
-      raise unless current_token.colon?
+      raise ParseError unless current_token.colon?
       value, made_from, type = add_current_token_to(value, type, made_from)
 
-      raise unless current_token.time?
+      raise ParseError unless current_token.time?
       value, made_from, type = add_current_token_to(value, type, made_from)
 
       token(value, type, start_index, made_from)

--- a/lib/opening_hours_converter/week_index.rb
+++ b/lib/opening_hours_converter/week_index.rb
@@ -7,7 +7,7 @@ module OpeningHoursConverter
     extend Utils
 
     def self.week_from_index(index, year = Time.now.year)
-      raise unless index >= 1
+      raise ArgumentError unless index >= 1
 
       week = first_week(year)
       offset = (index - 1) * 7
@@ -92,7 +92,7 @@ module OpeningHoursConverter
           first_day_of_the_week = first_day_of_month - first_wday_of_month
           first_day_of_the_week + wday + (n - 1) * 7
         end
-      raise 'Out of bound' unless date.month == month
+      raise ArgumentError, 'Out of bound' unless date.month == month
 
       date
     end
@@ -119,7 +119,7 @@ module OpeningHoursConverter
           first_day_of_the_week = last_day_of_month - last_wday_of_month
           first_day_of_the_week + wday
         end
-      raise 'Out of bound' unless date.month == month
+      raise ArgumentError, 'Out of bound' unless date.month == month
 
       date
     end

--- a/spec/week_index_spec.rb
+++ b/spec/week_index_spec.rb
@@ -1,7 +1,7 @@
 require 'opening_hours_converter'
 RSpec.describe OpeningHoursConverter::WeekIndex, '#week_from_index' do # (index, year = Time.now.year)
   it 'raises with out of range index' do
-    expect { OpeningHoursConverter::WeekIndex.week_from_index(0, 2019) }.to raise_error
+    expect { OpeningHoursConverter::WeekIndex.week_from_index(0, 2019) }.to raise_error(ArgumentError)
   end
 
   it 'does not raise with good index' do


### PR DESCRIPTION
This introduces some specific errors: ArgumentError and OpeningHoursConverter::ParseError

The latter can be used by callers and users of the lib to catch.

Currently we cannot catch errors in a nice and clean way; and parsing often goes wrong: there's loads of edgecases, not yet implemented features, or simply broken open_hours in OSM which will cause the parser to break now.

Allowing upstream to catch those makes the lib easier to use.