### PR TITLE
ci: test against a matrix of current Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
           - '3.4'
 
     steps:
-    - uses: actions/checkout@v6.0.0
+    - uses: actions/checkout@v6.0.1
 
     - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1.268.0
+      uses: ruby/setup-ruby@v1.278.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,27 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - '3.2'
+          - '3.3'
+          - '3.4'
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v6.0.0
+
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1.268.0
       with:
-        ruby-version: 2.6.x
-    - name: Build and test with Rspec
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rspec spec
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rspec spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,18 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        ruby-version:
-          - '3.2'
-          - '3.3'
-          - '3.4'
+        include:
+          # ruby/setup-ruby ships no 2.6 build for ubuntu-24.04, so that row
+          # needs the older runner.
+          - { ruby-version: '2.6.9', os: ubuntu-22.04 }
+          - { ruby-version: '3.2', os: ubuntu-latest }
+          - { ruby-version: '3.3', os: ubuntu-latest }
+          - { ruby-version: '3.4', os: ubuntu-latest }
 
     steps:
     - uses: actions/checkout@v6.0.1


### PR DESCRIPTION
## What?

I've added a matrix of current Ruby versions to the GitHub CI workflow.

## Why?

It is extremely useful to test against all current versions of Ruby.

## How?

This adds a testing strategy allowing us to setup and run the tests against Ruby 3.2, 3.3 and 3.4.

## Testing?

This works on my fork of the repo.

## Anything Else?

It is best practice to pin GitHub workflow actions to exact versions, hence the use of `actions/checkout@v6.0.0` and `ruby/setup-ruby@v1.268.0`

Thanks