### PR TITLE
fix: frozen string literal warning on Ruby 3.4

### DIFF
--- a/lib/opening_hours_converter/tokenizer.rb
+++ b/lib/opening_hours_converter/tokenizer.rb
@@ -62,7 +62,7 @@ module OpeningHoursConverter
     def handle_string
       type = :string
       start_index = @index
-      value = ''
+      value = String.new
 
       while string? && current_character?
         value << current_character
@@ -75,7 +75,7 @@ module OpeningHoursConverter
     def handle_integer
       type = :integer
       start_index = @index
-      value = ''
+      value = String.new
 
       while integer? && current_character?
         value << current_character

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -1,0 +1,102 @@
+require 'opening_hours_converter'
+
+describe OpeningHoursConverter::Tokenizer do
+  describe '#tokenize' do
+    context 'verifying mutable string creation' do
+      it 'creates mutable strings when tokenizing days' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('Mo-Fr 08:00-18:00')
+        expect(tokenizer.tokens).to be_an(Array)
+        # Verify all token values are mutable (not frozen)
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings when tokenizing times' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('08:00-18:00')
+        expect(tokenizer.tokens).to include('08:00-18:00')
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings when tokenizing years' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('2017-2018 Mo 08:00-10:00')
+        expect(tokenizer.tokens).to be_an(Array)
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings when tokenizing 24/7' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('24/7')
+        expect(tokenizer.tokens).to eq(['24/7'])
+        expect(tokenizer.tokens.first).not_to be_frozen
+      end
+
+      it 'creates mutable strings when tokenizing day ranges' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('Mo-We 08:00-10:00')
+        expect(tokenizer.tokens).to be_an(Array)
+        expect(tokenizer.tokens.length).to be > 0
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings when tokenizing with quotes' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('Mo-We 08:00-10:00 "salut"')
+        expect(tokenizer.tokens).to be_an(Array)
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings when tokenizing PH (public holidays)' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('PH off')
+        expect(tokenizer.tokens).to eq(['PH', 'off'])
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings when tokenizing month ranges' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('2017 Jun-Jul Sa 10:00-12:00')
+        expect(tokenizer.tokens).to be_an(Array)
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings when tokenizing date ranges' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('Nov 11-12 10:00-23:00')
+        expect(tokenizer.tokens).to be_an(Array)
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+
+      it 'creates mutable strings for empty input' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('')
+        expect(tokenizer.tokens).to eq([])
+      end
+
+      it 'creates mutable strings when tokenizing week ranges' do
+        tokenizer = OpeningHoursConverter::Tokenizer.new('week 1 off')
+        expect(tokenizer.tokens).to be_an(Array)
+        tokenizer.tokens.each do |token|
+          expect(token).not_to be_frozen
+        end
+      end
+    end
+
+    context 'integration with existing parser tests' do
+      it 'works correctly with the full parser' do
+        # This test verifies the tokenizer works end-to-end with the parser
+        input = 'Mo 08:00-10:00'
+        parsed = OpeningHoursConverter::OpeningHoursParser.new.parse(input)
+        rebuilt = OpeningHoursConverter::OpeningHoursBuilder.new.build(parsed)
+        expect(rebuilt).to eq(input)
+      end
+    end
+  end
+end

--- a/spec/tokenizer_spec.rb
+++ b/spec/tokenizer_spec.rb
@@ -1,102 +1,69 @@
 require 'opening_hours_converter'
+require 'stringio'
 
-describe OpeningHoursConverter::Tokenizer do
-  describe '#tokenize' do
-    context 'verifying mutable string creation' do
-      it 'creates mutable strings when tokenizing days' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('Mo-Fr 08:00-18:00')
-        expect(tokenizer.tokens).to be_an(Array)
-        # Verify all token values are mutable (not frozen)
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
+RSpec.describe OpeningHoursConverter::Tokenizer do
+  # Tokenizing runs from the constructor, and the tokens the reader exposes are
+  # the values the tokens handler kept, not the Token objects themselves.
+  #
+  # [opening hours string, tokens]
+  cases = [
+    ['Mo-Fr 08:00-18:00', ['Mo-Fr', '08:00-18:00']],
+    ['08:00-18:00', ['08:00-18:00']],
+    ['Mo-Fr 08:30-12:00,14:00-18:00', ['Mo-Fr', '08:30-12:00', '14:00-18:00']],
+    ['Mo-We 08:00-10:00 "salut"', ['Mo-We', '08:00-10:00', '"salut"']],
+    ['24/7', ['24/7']],
+    ['PH off', %w[PH off]],
+    ['2017-2018 Mo 08:00-10:00', ['2017-2018', 'Mo', '08:00-10:00']],
+    ['2017 Jun-Jul Sa 10:00-12:00', ['2017 Jun-Jul', 'Sa', '10:00-12:00']],
+    ['Nov 11-12 10:00-23:00', ['Nov 11-12', '10:00-23:00']],
+    ['week 1 off', ['week 1', 'off']],
+    ['We[1] 05:00-12:00', ['We[1]', '05:00-12:00']],
+    ['', []]
+  ].freeze
 
-      it 'creates mutable strings when tokenizing times' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('08:00-18:00')
-        expect(tokenizer.tokens).to include('08:00-18:00')
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
-
-      it 'creates mutable strings when tokenizing years' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('2017-2018 Mo 08:00-10:00')
-        expect(tokenizer.tokens).to be_an(Array)
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
-
-      it 'creates mutable strings when tokenizing 24/7' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('24/7')
-        expect(tokenizer.tokens).to eq(['24/7'])
-        expect(tokenizer.tokens.first).not_to be_frozen
-      end
-
-      it 'creates mutable strings when tokenizing day ranges' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('Mo-We 08:00-10:00')
-        expect(tokenizer.tokens).to be_an(Array)
-        expect(tokenizer.tokens.length).to be > 0
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
-
-      it 'creates mutable strings when tokenizing with quotes' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('Mo-We 08:00-10:00 "salut"')
-        expect(tokenizer.tokens).to be_an(Array)
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
-
-      it 'creates mutable strings when tokenizing PH (public holidays)' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('PH off')
-        expect(tokenizer.tokens).to eq(['PH', 'off'])
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
-
-      it 'creates mutable strings when tokenizing month ranges' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('2017 Jun-Jul Sa 10:00-12:00')
-        expect(tokenizer.tokens).to be_an(Array)
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
-
-      it 'creates mutable strings when tokenizing date ranges' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('Nov 11-12 10:00-23:00')
-        expect(tokenizer.tokens).to be_an(Array)
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
-      end
-
-      it 'creates mutable strings for empty input' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('')
-        expect(tokenizer.tokens).to eq([])
-      end
-
-      it 'creates mutable strings when tokenizing week ranges' do
-        tokenizer = OpeningHoursConverter::Tokenizer.new('week 1 off')
-        expect(tokenizer.tokens).to be_an(Array)
-        tokenizer.tokens.each do |token|
-          expect(token).not_to be_frozen
-        end
+  describe '#tokens' do
+    cases.each do |opening_hours, tokens|
+      it "tokenizes #{opening_hours.inspect}" do
+        expect(described_class.new(opening_hours).tokens).to eql(tokens)
       end
     end
 
-    context 'integration with existing parser tests' do
-      it 'works correctly with the full parser' do
-        # This test verifies the tokenizer works end-to-end with the parser
-        input = 'Mo 08:00-10:00'
-        parsed = OpeningHoursConverter::OpeningHoursParser.new.parse(input)
-        rebuilt = OpeningHoursConverter::OpeningHoursBuilder.new.build(parsed)
-        expect(rebuilt).to eq(input)
+    it 'exposes the token values as strings' do
+      expect(described_class.new('2017 Jun-Jul Sa 10:00-12:00').tokens).to all(be_a(String))
+    end
+  end
+
+  describe 'token values built character by character' do
+    # Ruby 3.4 chills the string literals of a file carrying no
+    # frozen_string_literal comment: mutating one warns. The tokenizer
+    # accumulates a token value character by character, so it has to start from a
+    # string of its own rather than from a literal. Below 3.4 there is no warning
+    # to observe and any assertion here would hold either way, hence the guard.
+    it 'warns about nothing in the tokenizer' do
+      skip 'chilled string literals arrived in Ruby 3.4' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4')
+
+      warnings = capture_deprecation_warnings do
+        described_class.new('2017 Jun-Jul Sa 10:00-12:00 "salut"')
       end
+
+      expect(warnings).not_to match(/tokenizer\.rb/)
+    end
+
+    # Matches on the file a warning points at rather than on its wording, which
+    # is not part of any contract, and lets an unrelated deprecation go by.
+    def capture_deprecation_warnings
+      was_deprecated = Warning[:deprecated]
+      real_stderr = $stderr
+      captured = StringIO.new
+
+      Warning[:deprecated] = true
+      $stderr = captured
+      yield
+
+      captured.string
+    ensure
+      $stderr = real_stderr
+      Warning[:deprecated] = was_deprecated
     end
   end
 end


### PR DESCRIPTION
## What?

I've updated the tokeniser to create mutable string values.

## Why?

Literal strings will be frozen by default in future versions of Ruby. Running the tokeniser in Ruby 3.4.7 produces those warnings `warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)`

## How?

This PR sets the value to `String.new` instead of `''` and adds tests to test the mutability of tokens.

## Testing?

Test have been added and all tests pass.

## Anything Else?

No, thanks